### PR TITLE
fix headless chromium installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:6-alpine
 
 RUN echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
+    && echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories \
+    && apk add --no-cache --upgrade apk-tools@edge
     && apk add --no-cache \
     python \
     build-base \


### PR DESCRIPTION
alpine-node6 doesn't install chromium from @edge.
This fixes it