### PR TITLE
Upgrade alpine-root-node16 to latest node 16 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:16-alpine3.13
+FROM node:16-alpine3.16
 
-RUN sed -i -e 's/v3.13/edge/g' /etc/apk/repositories  \
+RUN sed -i -e 's/v3.16/edge/g' /etc/apk/repositories  \
     && apk add --no-cache \
     python2 \
     build-base \


### PR DESCRIPTION
Upgrade to latest version of node 16.  

Currently this image can't be used for angular builds as it requires a newer version of node 16.  
Example output of failing CI:
```
Node.js version v16.0.0 detected.
The Angular CLI requires a minimum Node.js version of either v12.20, v14.15, or v16.10.
```